### PR TITLE
Add CircleCI support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: ubuntu:zesty
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: apt-get update -y && apt-get install libyaml-cpp-dev libsqlite3-dev util-linux librsvg2-dev libcairomm-1.0-dev libepoxy-dev libgtkmm-3.0-dev uuid-dev libboost-dev  libzmq5 libzmq3-dev libglm-dev -y
+      - run:
+          name: Build
+          command: make -j2


### PR DESCRIPTION
CirecleCI seems much better suited than TravisCI since one can just use any Docker container to build.