### PR TITLE
Add set-polygon parameter program command

### DIFF
--- a/pool/padstack.cpp
+++ b/pool/padstack.cpp
@@ -90,7 +90,11 @@ namespace horizon {
 			return {true, "not enough arguments"};
 
 		auto pclass = dynamic_cast<ParameterProgram::TokenString*>(cmd->arguments.at(0).get())->string;
-		int n_vertices = dynamic_cast<ParameterProgram::TokenInt*>(cmd->arguments.at(1).get())->value;
+		std::size_t n_vertices = dynamic_cast<ParameterProgram::TokenInt*>(cmd->arguments.at(1).get())->value;
+
+		if(stack.size() < 2 * n_vertices) {
+			return {true, "not enough coordinates on stack"};
+		}
 
 		for(auto &it: ps->polygons) {
 			if(it.second.parameter_class == pclass) {
@@ -98,7 +102,7 @@ namespace horizon {
 			}
 		}
 
-		for(int i = 0; i < n_vertices; i++) {
+		for(std::size_t i = 0; i < n_vertices; i++) {
 			Coordi c;
 			if(stack_pop(stack, c.y) || stack_pop(stack, c.x)) {
 				return {true, "empty stack"};

--- a/pool/padstack.cpp
+++ b/pool/padstack.cpp
@@ -90,25 +90,22 @@ namespace horizon {
 			return {true, "not enough arguments"};
 
 		auto pclass = dynamic_cast<ParameterProgram::TokenString*>(cmd->arguments.at(0).get())->string;
-		std::size_t n_vertices = dynamic_cast<ParameterProgram::TokenInt*>(cmd->arguments.at(1).get())->value;
-
-		Coordi positions[n_vertices];
-		for(int i = n_vertices - 1; i >= 0; --i) {
-			if(stack_pop(stack, positions[i].y) || stack_pop(stack, positions[i].x))
-				return {true, "empty stack"};
-		}
+		int n_vertices = dynamic_cast<ParameterProgram::TokenInt*>(cmd->arguments.at(1).get())->value;
 
 		for(auto &it: ps->polygons) {
 			if(it.second.parameter_class == pclass) {
-				if(it.second.vertices.size() != n_vertices) {
-					return {true, "polygon has wrong count of vertices"};
-				}
-				for(std::size_t i = 0, e = it.second.vertices.size(); i != e; ++i) {
-					if(it.second.vertices[i].type == Polygon::Vertex::Type::ARC) {
-						return {true, "polygon contains arc"};
-					}
-					it.second.vertices[i].position.x = positions[i].x;
-					it.second.vertices[i].position.y = positions[i].y;
+				it.second.vertices.clear();
+			}
+		}
+
+		for(int i = 0; i < n_vertices; i++) {
+			Coordi c;
+			if(stack_pop(stack, c.y) || stack_pop(stack, c.x)) {
+				return {true, "empty stack"};
+			}
+			for(auto &it: ps->polygons) {
+				if(it.second.parameter_class == pclass) {
+					it.second.vertices.push_front(Polygon::Vertex(c));
 				}
 			}
 		}

--- a/pool/padstack.hpp
+++ b/pool/padstack.hpp
@@ -28,6 +28,7 @@ namespace horizon {
 
 					std::pair<bool, std::string> set_shape(const ParameterProgram::TokenCommand *cmd, std::deque<int64_t> &stack);
 					std::pair<bool, std::string> set_hole(const ParameterProgram::TokenCommand *cmd, std::deque<int64_t> &stack);
+					std::pair<bool, std::string> set_polygon(const ParameterProgram::TokenCommand *cmd, std::deque<int64_t> &stack);
 
 				public:
 					MyParameterProgram(class Padstack *p, const std::string &code);


### PR DESCRIPTION
I needed polygon shaped pads for an UFQFPN20 footprint.
![2017-12-28-162742_800x900_scrot](https://user-images.githubusercontent.com/11243448/34414942-53e214e4-ebec-11e7-8c4f-40cd3f497e88.png)
I found no good way to enable parametrisation with parameter programs, so I added the `set-polygon` command which can set each vertex' coordinates individually.

`set-polygon [ <parameter class> <n_vertices> ]` takes 2 * n_vertices values from the stack (x and y alternating) and sets the polygon's vertex coordinates to those. Polygons with arcs or with any other number of vertices than n_vertices currently throw an error.