### PR TITLE
Use "previous" icon instead of close button, separate buttons to prevent confusion

### DIFF
--- a/src/pool-mgr/window.ui
+++ b/src/pool-mgr/window.ui
@@ -474,19 +474,19 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>
-	    <property name="tooltip-text" translatable="yes">Return to pool list</property>
+            <property name="tooltip-text" translatable="yes">Return to pool list</property>
 
-	    <child>
-	      <object class="GtkImage" id="navigation_previous_icon">
-		<property name="visible">True</property>
-		<property name="icon-name">go-previous-symbolic</property>
-		<property name="icon-size">1</property>
+            <child>
+              <object class="GtkImage" id="navigation_previous_icon">
+                <property name="visible">True</property>
+                <property name="icon-name">go-previous-symbolic</property>
+                <property name="icon-size">1</property>
               </object>
-	    </child>
+            </child>
           </object>
           <packing>
             <property name="position">3</property>
-	    <property name="pack-type">start</property>
+            <property name="pack-type">start</property>
           </packing>
         </child>
         <child>
@@ -498,7 +498,7 @@
           </object>
           <packing>
             <property name="position">2</property>
-	    <property name="pack-type">start</property>
+            <property name="pack-type">start</property>
           </packing>
         </child>
         <child>
@@ -510,7 +510,7 @@
           </object>
           <packing>
             <property name="position">4</property>
-	    <property name="pack-type">end</property>
+            <property name="pack-type">end</property>
           </packing>
         </child>
         <child>
@@ -522,7 +522,7 @@
           </object>
           <packing>
             <property name="position">4</property>
-	    <property name="pack-type">start</property>
+            <property name="pack-type">start</property>
           </packing>
         </child>
         <child>
@@ -532,7 +532,7 @@
           </object>
           <packing>
             <property name="position">5</property>
-	    <property name="pack-type">end</property>
+            <property name="pack-type">end</property>
           </packing>
         </child>
         <child>

--- a/src/pool-mgr/window.ui
+++ b/src/pool-mgr/window.ui
@@ -510,7 +510,7 @@
           </object>
           <packing>
             <property name="position">4</property>
-            <property name="pack-type">end</property>
+            <property name="pack-type">start</property>
           </packing>
         </child>
         <child>
@@ -532,7 +532,7 @@
           </object>
           <packing>
             <property name="position">5</property>
-            <property name="pack-type">end</property>
+            <property name="pack-type">start</property>
           </packing>
         </child>
         <child>

--- a/src/pool-mgr/window.ui
+++ b/src/pool-mgr/window.ui
@@ -474,7 +474,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>
-	    <property name="tooltip-text" translatable="yes">Return to pull list</property>
+	    <property name="tooltip-text" translatable="yes">Return to pool list</property>
 
 	    <child>
 	      <object class="GtkImage" id="navigation_previous_icon">

--- a/src/pool-mgr/window.ui
+++ b/src/pool-mgr/window.ui
@@ -471,13 +471,22 @@
         </child>
         <child>
           <object class="GtkButton" id="button_close">
-            <property name="label" translatable="yes">Close</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>
+	    <property name="tooltip-text" translatable="yes">Return to pull list</property>
+
+	    <child>
+	      <object class="GtkImage" id="navigation_previous_icon">
+		<property name="visible">True</property>
+		<property name="icon-name">go-previous-symbolic</property>
+		<property name="icon-size">1</property>
+              </object>
+	    </child>
           </object>
           <packing>
             <property name="position">3</property>
+	    <property name="pack-type">start</property>
           </packing>
         </child>
         <child>
@@ -489,6 +498,7 @@
           </object>
           <packing>
             <property name="position">2</property>
+	    <property name="pack-type">start</property>
           </packing>
         </child>
         <child>
@@ -500,6 +510,7 @@
           </object>
           <packing>
             <property name="position">4</property>
+	    <property name="pack-type">end</property>
           </packing>
         </child>
         <child>
@@ -511,6 +522,7 @@
           </object>
           <packing>
             <property name="position">4</property>
+	    <property name="pack-type">start</property>
           </packing>
         </child>
         <child>
@@ -520,6 +532,7 @@
           </object>
           <packing>
             <property name="position">5</property>
+	    <property name="pack-type">end</property>
           </packing>
         </child>
         <child>


### PR DESCRIPTION
I find the "Close" button inappropriate in the Pool Manager, I think that a "Previous" button would be more appropriate.

I also used different packing position to separate "Previous" action and "Update pool" action.