### PR TITLE
Replace "close" button in project view with a "previous" button

### DIFF
--- a/src/prj-mgr/window.ui
+++ b/src/prj-mgr/window.ui
@@ -743,10 +743,18 @@
         </child>
         <child>
           <object class="GtkButton" id="button_close">
-            <property name="label" translatable="yes">Close</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>
+            <property name="tooltip-text" translatable="yes">Return to project list</property>
+
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="icon-name">go-previous-symbolic</property>
+                <property name="icon-size">1</property>
+              </object>
+            </child>
           </object>
           <packing>
             <property name="position">2</property>


### PR DESCRIPTION
Similar to #80 but applies to project manager.