### PR TITLE
Replace new/open project button labels with icons

### DIFF
--- a/src/prj-mgr/window.ui
+++ b/src/prj-mgr/window.ui
@@ -724,18 +724,34 @@
         <property name="show_close_button">True</property>
         <child>
           <object class="GtkButton" id="button_new">
-            <property name="label" translatable="yes">New...</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>
+            <property name="tooltip-text">New project</property>
+
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="icon-name">document-new-symbolic</property>
+                <property name="icon-size">1</property>
+              </object>
+            </child>
           </object>
         </child>
         <child>
           <object class="GtkButton" id="button_open">
-            <property name="label" translatable="yes">Open...</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>
+            <property name="tooltip-text">Open project</property>
+
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="icon-name">document-open-symbolic</property>
+                <property name="icon-size">1</property>
+              </object>
+            </child>
           </object>
           <packing>
             <property name="position">1</property>


### PR DESCRIPTION
![capture d ecran_2018-02-09_14-01-50](https://user-images.githubusercontent.com/25333063/36029047-db8b645a-0da1-11e8-80b3-6f846f9f45ff.png)

Tooltips were added to the buttons