### PR TITLE
Support building on FreeBSD 11.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -475,6 +475,7 @@ OBJ_OCE = $(SRC_OCE:.cpp=.o)
 
 INC_ROUTER = -I3rd_party/router/include/ -I3rd_party/router -I3rd_party
 INC_OCE = -I/opt/opencascade/inc/ -I/mingw64/include/oce/ -I/usr/include/oce -I/usr/include/opencascade
+INC_OCE+= -I/usr/local/include/OpenCASCADE
 LDFLAGS_OCE = -L /opt/opencascade/lib/ -lTKSTEP  -lTKernel  -lTKXCAF -lTKXSBase -lTKBRep -lTKCDF -lTKXDESTEP -lTKLCAF -lTKMath -lTKMesh -lTKTopAlgo -lTKPrim -lTKBO -lTKG3d
 ifeq ($(OS),Windows_NT)
 	LDFLAGS_OCE += -lTKV3d

--- a/src/canvas/selectables.hpp
+++ b/src/canvas/selectables.hpp
@@ -28,10 +28,10 @@ public:
 
 class SelectableRef {
 public:
-    const UUID uuid;
-    const ObjectType type;
-    const unsigned int vertex;
-    const int layer;
+    UUID uuid;
+    ObjectType type;
+    unsigned int vertex;
+    int layer;
     SelectableRef(const UUID &uu, ObjectType ty, unsigned int v = 0, int la = 10000)
         : uuid(uu), type(ty), vertex(v), layer(la)
     {

--- a/src/common/lut.hpp
+++ b/src/common/lut.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <string>
 #include <map>
 
 namespace horizon {

--- a/src/imp/imp_board.cpp
+++ b/src/imp/imp_board.cpp
@@ -303,7 +303,7 @@ void ImpBoard::construct()
             default:;
             }
         }
-        update_highlights();
+        this->update_highlights();
     });
 
     auto *display_control_notebook = Gtk::manage(new Gtk::Notebook);

--- a/src/imp/imp_schematic.cpp
+++ b/src/imp/imp_schematic.cpp
@@ -336,7 +336,7 @@ void ImpSchematic::construct()
             default:;
             }
         }
-        update_highlights();
+        this->update_highlights();
     });
 
 

--- a/src/pool/symbol.hpp
+++ b/src/pool/symbol.hpp
@@ -26,7 +26,7 @@ public:
     SymbolPin(const UUID &uu, const json &j);
     SymbolPin(UUID uu);
 
-    const UUID uuid;
+    UUID uuid;
     Coord<int64_t> position;
     uint64_t length;
     bool name_visible;

--- a/src/schematic/bus_label.hpp
+++ b/src/schematic/bus_label.hpp
@@ -24,7 +24,7 @@ public:
     BusLabel(const UUID &uu, const json &j, class Sheet &sheet, class Block &block);
     BusLabel(const UUID &uu);
 
-    const UUID uuid;
+    UUID uuid;
 
     enum class Style { PLAIN, FLAG };
     Style style = Style::FLAG;

--- a/src/schematic/bus_ripper.hpp
+++ b/src/schematic/bus_ripper.hpp
@@ -23,7 +23,7 @@ public:
     BusRipper(const UUID &uu, const json &j, class Sheet &sheet, class Block &block);
     BusRipper(const UUID &uu);
     virtual UUID get_uuid() const;
-    const UUID uuid;
+    UUID uuid;
     bool temp = false;
 
     uuid_ptr<Junction> junction;

--- a/src/schematic/line_net.hpp
+++ b/src/schematic/line_net.hpp
@@ -38,7 +38,7 @@ public:
     UUID net_segment = UUID();
 
 
-    const UUID uuid;
+    UUID uuid;
 
     class Connection {
     public:

--- a/src/schematic/net_label.hpp
+++ b/src/schematic/net_label.hpp
@@ -23,7 +23,7 @@ public:
     NetLabel(const UUID &uu, const json &j, class Sheet *sheet = nullptr);
     NetLabel(const UUID &uu);
 
-    const UUID uuid;
+    UUID uuid;
 
     enum class Style { PLAIN, FLAG };
     Style style = Style::FLAG;

--- a/src/schematic/power_symbol.hpp
+++ b/src/schematic/power_symbol.hpp
@@ -25,7 +25,7 @@ public:
     PowerSymbol(const UUID &uu, const json &j, class Sheet *sheet = nullptr, class Block *block = nullptr);
     PowerSymbol(const UUID &uu);
 
-    const UUID uuid;
+    UUID uuid;
     uuid_ptr<Junction> junction;
     uuid_ptr<Net> net;
     bool mirror = false;


### PR DESCRIPTION
This is a set of patches which enables building Horizon EDA on FreeBSD 11.1 with its default compiler Clang 4.0.0 and the libc++.

The patches also address issues reported in #69 with regard to copy assignment operators being is implicitly deleted. It seems that the default copy assignment operator is not allowed on classes which have `const` data members.