### PR TITLE
Use sysctl instead of procfs for FreeBSD

### DIFF
--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -78,13 +78,15 @@ std::string get_exe_dir()
     }
 }
 #elif defined(__FreeBSD__)
+#include <sys/sysctl.h>
 std::string get_exe_dir()
 {
-
     char buf[PATH_MAX];
-    ssize_t len;
-    if ((len = readlink("/proc/curproc/file", buf, sizeof(buf) - 1)) != -1) {
-        buf[len] = '\0';
+    size_t len = sizeof(buf);
+    int mib[] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
+    int ret;
+    ret = sysctl(mib, 4, buf, &len, NULL, 0);
+    if (ret == 0) {
         return Glib::path_get_dirname(buf);
     }
     else {


### PR DESCRIPTION
FreeBSD user no longer need to mount /proc, which has been deprecated
and is not mounted by default.

According to Wikipedia:
  "As of February 2011, procfs is gradually becoming phased out in
  FreeBSD."

sysctl() and the parameters are documented in the FreeBSD sysctl()
manual page. Tested on FreeBSD 11.1-RELEASE.