### PR TITLE
log_view: fixed assertion on Logs->"Follow"

### DIFF
--- a/src/widgets/log_view.cpp
+++ b/src/widgets/log_view.cpp
@@ -52,8 +52,10 @@ LogView::LogView() : Gtk::Box(Gtk::ORIENTATION_VERTICAL, 0)
         follow = follow_cb->get_active();
         if (follow) {
             auto it = store->children().end();
-            it--;
-            tree_view->scroll_to_row(store->get_path(it));
+            if (it) {
+                it--;
+                tree_view->scroll_to_row(store->get_path(it));
+            }
         }
     });
     bbox->pack_start(*follow_cb, false, false, 0);


### PR DESCRIPTION
To reproduce:
1. Open "Logs" view.
2. Click "Clear"
3. Click "Follow" at least twice.

Generates:
(horizon-imp:6732): Gtk-CRITICAL **: gtk_tree_view_scroll_to_cell: assertion 'tree_view->priv->tree != NULL' failed

The iterator seems to be invalid at this point.