### PR TITLE
Pool manager: take package graphical elements into account for default zoom level

### DIFF
--- a/src/pool/package.cpp
+++ b/src/pool/package.cpp
@@ -342,6 +342,11 @@ std::pair<Coordi, Coordi> Package::get_bbox() const
         a = Coordi::min(a, bb_pad.first);
         b = Coordi::max(b, bb_pad.second);
     }
+    for (const auto &it : junctions) {
+        auto pos = it.second.position;
+        a = Coordi::min(a, pos);
+        b = Coordi::max(b, pos);
+    }
     return std::make_pair(a, b);
 }
 

--- a/src/widgets/preview_canvas.cpp
+++ b/src/widgets/preview_canvas.cpp
@@ -24,7 +24,6 @@ void PreviewCanvas::load(ObjectType type, const UUID &uu, const Placement &pl, b
         sym.apply_placement(pl);
         update(sym, pl);
         bb = sym.get_bbox();
-        pad = 1_mm;
     } break;
 
     case ObjectType::PACKAGE: {
@@ -40,11 +39,12 @@ void PreviewCanvas::load(ObjectType type, const UUID &uu, const Placement &pl, b
         property_layer_opacity() = 75;
         update(pkg);
         bb = pkg.get_bbox();
-        pad = 1_mm;
-        bb.first.x -= pad;
     } break;
     default:;
     }
+
+    pad = std::max(bb.second.x, bb.second.y);
+    pad /= 1.61803;
 
     bb.first.x -= pad;
     bb.first.y -= pad;

--- a/src/widgets/preview_canvas.hpp
+++ b/src/widgets/preview_canvas.hpp
@@ -5,7 +5,7 @@ namespace horizon {
 class PreviewCanvas : public CanvasGL {
 public:
     PreviewCanvas(class Pool &pool);
-    void load(ObjectType ty, const UUID &uu, const Placement &pl = Placement(), bool fit = false);
+    void load(ObjectType ty, const UUID &uu, const Placement &pl = Placement(), bool fit = true);
 
 private:
     class Pool &pool;


### PR DESCRIPTION
This patch set changes the way default zoom level is calculated in the pool manager. For packages, it tries to take graphical elements into account in addition to pads.