### PR TITLE
Part wizard pin import from CSV file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ SRC_COMMON = \
 	src/pool/pool.cpp \
 	src/util/placement.cpp\
 	src/util/util.cpp\
+	src/util/csv.cpp\
 	src/common/object_descr.cpp\
 	src/block/net_class.cpp\
 	src/project/project.cpp\

--- a/src/pool-prj-mgr/pool-mgr/part_wizard/part_wizard.cpp
+++ b/src/pool-prj-mgr/pool-mgr/part_wizard/part_wizard.cpp
@@ -447,7 +447,7 @@ void pads_from_csv(CSV::csv &csv, json &j)
 void PartWizard::handle_import()
 {
     GtkFileChooserNative *native =
-            gtk_file_chooser_native_new("Open", gobj(), GTK_FILE_CHOOSER_ACTION_OPEN, "_Save", "_Cancel");
+            gtk_file_chooser_native_new("Open", gobj(), GTK_FILE_CHOOSER_ACTION_OPEN, "_Open", "_Cancel");
     auto chooser = Glib::wrap(GTK_FILE_CHOOSER(native));
     auto filter = Gtk::FileFilter::create();
     filter->set_name("CSV documents");

--- a/src/pool-prj-mgr/pool-mgr/part_wizard/part_wizard.cpp
+++ b/src/pool-prj-mgr/pool-mgr/part_wizard/part_wizard.cpp
@@ -7,6 +7,7 @@
 #include "util/str_util.hpp"
 #include "util/gtk_util.hpp"
 #include "util/pool_completion.hpp"
+#include "util/csv.hpp"
 #include "nlohmann/json.hpp"
 #include "pool-prj-mgr/pool-prj-mgr-app_win.hpp"
 
@@ -427,12 +428,32 @@ void PartWizard::handle_unlink()
     pads_lb->invalidate_sort();
 }
 
+void pads_from_csv(CSV::csv &csv, json &j)
+{
+    for (auto &line : csv) {
+        /* We need at least a non-zero pad name. */
+        if (line.size() < 1) {
+            continue;
+        }
+        std::string name = line[0];
+        trim(name);
+        if (name.empty()) {
+            continue;
+        }
+        j[name] = json_from_fields(line, {"", "pin", "", "gate"});
+    }
+}
+
 void PartWizard::handle_import()
 {
     GtkFileChooserNative *native =
             gtk_file_chooser_native_new("Open", gobj(), GTK_FILE_CHOOSER_ACTION_OPEN, "_Save", "_Cancel");
     auto chooser = Glib::wrap(GTK_FILE_CHOOSER(native));
     auto filter = Gtk::FileFilter::create();
+    filter->set_name("CSV documents");
+    filter->add_pattern("*.csv");
+    chooser->add_filter(filter);
+    filter = Gtk::FileFilter::create();
     filter->set_name("json documents");
     filter->add_pattern("*.json");
     chooser->add_filter(filter);
@@ -445,8 +466,15 @@ void PartWizard::handle_import()
             if (!ifs.is_open()) {
                 throw std::runtime_error("file " + filename + " not opened");
             }
-            ifs >> j;
-            ifs.close();
+            if (endswith(filename, ".json")) {
+                ifs >> j;
+                ifs.close();
+            } else {
+                CSV::csv csv;
+                ifs >> csv;
+                ifs.close();
+                pads_from_csv(csv, j);
+            }
             import_pads(j);
         }
         catch (const std::exception &e) {

--- a/src/util/csv.cpp
+++ b/src/util/csv.cpp
@@ -1,0 +1,100 @@
+#include "csv.hpp"
+#include <istream>
+
+namespace CSV {
+csv::csv(const std::string &delim) : delim(delim)
+{
+}
+
+std::size_t csv::size() const
+{
+    return val.size();
+}
+
+const std::vector<std::string> &csv::operator[](std::size_t i) const
+{
+    return val[i];
+}
+
+std::vector<std::vector<std::string>>::const_iterator csv::begin() const
+{
+    return val.begin();
+}
+
+std::vector<std::vector<std::string>>::const_iterator csv::end() const
+{
+  return val.end();
+}
+
+enum class State { Q0, Q1, ESC };
+
+bool csv::isdelim(char c)
+{
+    return delim.find_first_of(c) != std::string::npos;
+}
+
+void csv::parseline(const std::string &line)
+{
+    State state = State::Q0;
+    std::vector<std::string> field;
+    std::string str;
+
+    for (char c : line) {
+        if (state == State::Q0) {
+            if (c == '\"') {
+                /* input: foo" */
+                state = State::Q1;
+            } else if (isdelim(c)) {
+                /* input: foo, */
+                field.push_back(str);
+                str = "";
+            } else {
+                /* input: fooc */
+                str += c;
+            }
+        } else if (state == State::Q1) {
+            if (c == '\"') {
+                /* input: "foo" */
+                state = State::ESC;
+            } else {
+                /* input: "fooc */
+                str += c;
+            }
+        } else if (state == State::ESC) {
+            if (c == '\"') {
+                /* input: "foo"" */
+                str += c;
+                state = State::Q1;
+            } else if (isdelim(c)) {
+                /* input: "foo", */
+                field.push_back(str);
+                str = "";
+                state = State::Q0;
+            } else {
+                /* input: "foo"c */
+                str += c;
+                state = State::Q0;
+            }
+        }
+    }
+    field.push_back(str);
+    val.push_back(field);
+}
+
+std::istream &operator>>(std::istream& is, csv &csv)
+{
+    while (!is.eof()) {
+        std::string line;
+        std::getline(is, line);
+        csv.parseline(line);
+    }
+
+    if (0) {
+        is.setstate(std::ios::failbit);
+    }
+
+    return is;
+}
+
+} // namespace CSV
+

--- a/src/util/csv.hpp
+++ b/src/util/csv.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+/*
+ * Specification
+ * 1. Fields are separated by a user specified delimiter (default comma) and
+ *    newline.
+ * 2. White space is never touched.
+ * 3. A field may be enclosed in double-quote characters "...".
+ * 4. A quoted field may contain commas.
+ * 5. A sequence of "" inside a quoted field is interpreted as a single '"'.
+ * 6. Fields may be empty; "" and an empty string both represent an empty field.
+ *
+ * Another description for quote mode (3., 4., 5. above):
+ * - When not in quote mode, a double-quote enters quote mode.
+ * - In quote mode, a double-quote not followed by a double-quote exits quote
+ *   mode.
+ * - In quote mode, the sequence "" is emitted as a single '"'.
+ * - Delimiters have no special meaning in quote mode.
+ *
+ * Consequences:
+ * - Quote mode does not nest.
+ * - A line should have an even number of double-quote characters.
+ */
+
+#include <string>
+#include <vector>
+
+namespace CSV {
+
+class csv {
+public:
+    csv(const std::string &delim = ",");
+    void parseline(const std::string &line);
+    std::size_t size() const;
+    const std::vector<std::string> &operator[](std::size_t i) const;
+    std::vector<std::vector<std::string>>::const_iterator begin() const;
+    std::vector<std::vector<std::string>>::const_iterator end() const;
+
+private:
+    bool isdelim(char c);
+    std::vector<std::vector<std::string>> val;
+    std::string delim;
+};
+
+std::istream &operator>>(std::istream& is, csv &obj);
+
+} // namespace CSV
+

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -40,6 +40,18 @@ json json_from_resource(const std::string &rsrc)
     return json::parse((const char *)json_bytes->get_data(size));
 }
 
+json json_from_fields(const std::vector<std::string> &field, const std::vector<std::string> &name)
+{
+    json j;
+    for (size_t i = 0; i < field.size() && name.size(); i++) {
+        if (field[i].empty() || name[i].empty()) {
+            continue;
+        }
+        j[name[i]] = (std::string) field[i];
+    }
+    return j;
+}
+
 int orientation_to_angle(Orientation o)
 {
     int angle = 0;

--- a/src/util/util.hpp
+++ b/src/util/util.hpp
@@ -44,4 +44,6 @@ std::string get_config_dir();
 
 void replace_backslash(std::string &path);
 json json_from_resource(const std::string &rsrc);
+/* Create string objects from name template. Empty fields and names are ignored. */
+json json_from_fields(const std::vector<std::string> &field, const std::vector<std::string> &name);
 } // namespace horizon


### PR DESCRIPTION
As discussed in #184, CSV is indeed convenient for the user. This pull request is a simple implementation, not very flexible, but it works. "Verified" with a CSV file for a 484 pin BGA FPGA and with UTF-8 characters.

Format is currently: `padname,pinname,,gate`.

The CSV translation to JSON could possibly be extended with some format specification and used for other things.