### PR TITLE
Frame: fix typos

### DIFF
--- a/src/dialogs/pool_browser_dialog.cpp
+++ b/src/dialogs/pool_browser_dialog.cpp
@@ -48,7 +48,7 @@ PoolBrowserDialog::PoolBrowserDialog(Gtk::Window *parent, ObjectType type, Pool 
         break;
     case ObjectType::FRAME:
         browser = Gtk::manage(new PoolBrowserFrame(pool));
-        set_title("Select Padstack");
+        set_title("Select Frame");
         break;
     default:;
     }

--- a/src/imp/action_catalog.cpp
+++ b/src/imp/action_catalog.cpp
@@ -558,7 +558,7 @@ const std::vector<std::pair<ActionGroup, std::string>> action_group_catalog = {
         {ActionGroup::MOVE, "Move"},           {ActionGroup::BOARD, "Board"},
         {ActionGroup::SCHEMATIC, "Schematic"}, {ActionGroup::SYMBOL, "Symbol"},
         {ActionGroup::PADSTACK, "Padstack"},   {ActionGroup::PACKAGE, "Package"},
-        {ActionGroup::FRAME, "Fame"},          {ActionGroup::UNDO, "Undo"},
+        {ActionGroup::FRAME, "Frame"},         {ActionGroup::UNDO, "Undo"},
         {ActionGroup::LAYER, "Layer"},         {ActionGroup::SELECTION, "Selection"},
         {ActionGroup::RULES, "Rules"},         {ActionGroup::UNKNOWN, "Misc"},
         {ActionGroup::VIEW, "View"},


### PR DESCRIPTION
The new frame/title block functionality works very well! Two minor typos spotted.