### PR TITLE
initial net label size fixup

### DIFF
--- a/src/core/tool_helper_draw_net_setting.hpp
+++ b/src/core/tool_helper_draw_net_setting.hpp
@@ -10,7 +10,7 @@ public:
     public:
         json serialize() const override;
         void load_from_json(const json &j) override;
-        uint64_t net_label_size = 1.5;
+        uint64_t net_label_size = 1.5_mm;
     };
 
     const ToolSettings *get_settings_const() const override
@@ -20,7 +20,7 @@ public:
 
     ToolID get_tool_id_for_settings() const override
     {
-        return ToolID::DRAW_LINE;
+        return ToolID::DRAW_NET;
     }
 
 protected:


### PR DESCRIPTION
Before: "net_label_size" defaulted to 0 mm and stored in
DRAW_LINE.json.

Now: defaults to 1.5 mm and stored in DRAW_NET.json.